### PR TITLE
better safeguards around query param destructuring

### DIFF
--- a/src/http/get-events/index.mjs
+++ b/src/http/get-events/index.mjs
@@ -14,8 +14,8 @@ const client = contentful.createClient({
 
 // learn more about HTTP functions here: https://arc.codes/http
 export async function handler (req) {
-  const { queryStringParameters = {} } = req;
-  const { id, tag } = queryStringParameters;
+  const params = req.queryStringParameters || {};
+  const { id, tag } = params;
 
   let events = (await client.getEntries('Event'))
     .items.map((event) => {
@@ -40,7 +40,7 @@ export async function handler (req) {
       };
     });
 
-  if (queryStringParameters) {
+  if (params) {
     if (id) {
       events = events.filter(event => parseInt(event.id, 10) === parseInt(queryStringParameters.id, 10));
     } else if (tag) {


### PR DESCRIPTION
resolves #13 

----

Should have tested before merging.... 🤦 

API Gateway did not like the destructuring it seems as API was now returning 500 and throwing this error in the logs
```sh
Sun Oct 23 20:41:00 UTC 2022 : Endpoint response body before transformations: {"errorType":"TypeError","errorMessage":"Cannot destructure property 'id' of 'queryStringParameters' as it is null.","trace":["TypeError: Cannot destructure property 'id' of 'queryStringParameters' as it is null.","    at Runtime.handler (file:///var/task/index.mjs:18:11)","    at Runtime.handleOnceNonStreaming (/var/runtime/Runtime.js:73:25)"]}
Sun Oct 23 20:41:00 UTC 2022 : Lambda execution failed with status 200 due to customer function error: Cannot destructure property 'id' of 'queryStringParameters' as it is null.. Lambda request id: 88d8bbd4-5a01-4f3c-8d57-77655d398522
Sun Oct 23 20:41:00 UTC 2022 : Method completed with status: 502
```