### PR TITLE
expose link field for events API

### DIFF
--- a/src/http/get-events/index.mjs
+++ b/src/http/get-events/index.mjs
@@ -19,7 +19,7 @@ export async function handler (req) {
 
   let events = (await client.getEntries('Event'))
     .items.map((event) => {
-      const { id, description, endTime, startTime, title } = event.fields;
+      const { id, description, endTime, startTime, title, link } = event.fields;
       const { tags = [] } = event.metadata;
 
       return {
@@ -34,6 +34,7 @@ export async function handler (req) {
         }),
         startTime: new Date(startTime).getTime() / 1000,
         endTime: new Date(endTime).getTime() / 1000,
+        link,
         tags: tags.map((tag) => {
           return tag.sys.id;
         })


### PR DESCRIPTION
resolves #19 

<details>
  except of local response from Contentful
  <pre>
  ","startTime":1665532800,"endTime":1665536400,"link":"https://www.facebook.com/events/414089587547058/","tags":["tt"]},{"id":44,"title":"Tuesday's Tunes - 10/25/2022","description":"<p>Join us for another evening of <a href=\"https://www.facebook.com/events/1986782928185130\">Tuesday&#39;s Tunes</a>!  We are very excited to be unveiling our new website during the show. Tune-in and say hello to Tunesy!</p>","startTime":1666742400,"endTime":1666746000,"link":"https://www.facebook.com/events/1986782928185130","tags":["tt"]},{"id":25,"title":"Tuesday's Tunes - 
  </pre>
</details>