### PR TITLE
feature/issue 26 add v2 albums resource API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,30 @@
 Serverless APIs for [www.analogstudios.net](https://github.com/AnalogStudiosRI/www.analogstudios.net) (and friends) using [arc.codes](https://arc.codes/).
 
 ## Supported APIs
-### `events`
+### Albums
+Structured events content sourced from [**Contentful**](https://planetscale.com) around the **Album** resource type.  Available at `/albums` internally and publicly as `/api/v2/albums`.
+
+_Options:_
+- `?id=xxx` - Filter by the `id` of the album
+- `?artistId=xxx` - Filter by the `id` of an artist
+
+> _You can only pass one or the other_
+
+
+### Events
 Structured events content sourced from [**Contentful**](https://contentful.com/) around the **Event** resource type.  Available at `/events` internally and publicly as `/api/v2/events`.
 
 _Options:_
-- `?id=n` - Filter by the ID of the event
+- `?id=xxx` - Filter by the `id` of the event
 - `?tag=xxx` - Filter by tags of the event
 
 > _You can only pass one or the other_
 
-### `posts`
-Structured events content sourced from the [**PlanetScale**](https://contentful.com/) database around the **Posts** resource type.  Available at `/posts` internally and publicly as `/api/v2/posts`.
+### Posts
+Structured events content sourced from the [**PlanetScale**](https://planetscale.com) database around the **Post** resource type.  Available at `/posts` internally and publicly as `/api/v2/posts`.
 
 _Options:_
-- `?id=n` - Filter by the ID of the post
+- `?id=xxx` - Filter by the `id` of a post
 
 ## Setup
 

--- a/app.arc
+++ b/app.arc
@@ -3,6 +3,7 @@ api
 
 @http
 get /
+get /albums
 get /events
 get /posts
 post /publish

--- a/src/http/get-albums/index.mjs
+++ b/src/http/get-albums/index.mjs
@@ -1,0 +1,20 @@
+import mysql from 'mysql2/promise';
+
+export async function handler (req) {
+  const params = req.queryStringParameters || {};
+  const { id } = params;
+  const connection = await mysql.createConnection(process.env.DATABASE_URL);
+  const [rows] = id
+    ? await connection.execute('SELECT * FROM albums WHERE id = ?', [id])
+    : await connection.execute('SELECT * FROM albums');
+
+  return {
+    statusCode: 200,
+    headers: {
+      'cache-control': 'max-age=604800',
+      'content-type': 'application/json',
+      'Access-Control-Allow-Origin': '*'
+    },
+    body: JSON.stringify(rows)
+  };
+}

--- a/src/http/get-albums/index.mjs
+++ b/src/http/get-albums/index.mjs
@@ -2,11 +2,13 @@ import mysql from 'mysql2/promise';
 
 export async function handler (req) {
   const params = req.queryStringParameters || {};
-  const { id } = params;
+  const { id, artistId } = params;
   const connection = await mysql.createConnection(process.env.DATABASE_URL);
   const [rows] = id
     ? await connection.execute('SELECT * FROM albums WHERE id = ?', [id])
-    : await connection.execute('SELECT * FROM albums');
+    : artistId
+      ? await connection.execute('SELECT * FROM albums WHERE artistId = ?', [artistId])
+      : await connection.execute('SELECT * FROM albums');
 
   return {
     statusCode: 200,


### PR DESCRIPTION
resolves #26 

![Screen Shot 2023-11-24 at 1 53 58 PM](https://github.com/AnalogStudiosRI/api/assets/895923/6dcf2c71-5a16-407b-88ff-2b10adc3a0b0)

1. Create `/albums` endpoint
1. Reflect existing API with filter by `id` query param
1. Reflect existing API with filter by an `artistId` query param
1. Add documentation in README

----

**TODO**
1. [x] Support filtering by `?artistId` query param
1. [x] Document in README.md (move to own README doc?)
1. [x] Test with downstream projects(s) / validate all content - https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/97