### PR TITLE
enhancement/align AWS SDK and NodeJS Lambda configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,17 @@
 ## Overview
 Serverless APIs for [www.analogstudios.net](https://github.com/AnalogStudiosRI/www.analogstudios.net) (and friends) using [arc.codes](https://arc.codes/).
 
+## Local Setup
+
+Assumes valid [AWS credentials](https://arc.codes/docs/en/get-started/detailed-aws-setup) are either exported as environment variables or you have a relevant configuration setup in _~/aws/credentials_.
+
+1. Clone the repo
+1. Run `npm ci`
+1. Run `npm run arc env`
+1. Run `npm start`  to use the local sandbox for development
+
 ## Supported APIs
+
 ### Albums
 Structured events content sourced from [**Contentful**](https://planetscale.com) around the **Album** resource type.  Available at `/albums` internally and publicly as `/api/v2/albums`.
 
@@ -33,17 +43,3 @@ Structured events content sourced from the [**PlanetScale**](https://planetscale
 
 _Options:_
 - `?id=xxx` - Filter by the `id` of a post
-
-## Setup
-
-Assumes valid [AWS credentials](https://arc.codes/docs/en/get-started/detailed-aws-setup) are either exported as environment variables or you have a relevant configuration setup in _~/aws/credentials_.
-
-1. Clone the repo
-1. Run `npm run ci`
-1. Run `npm run arc env`
-
-## Local Development
-
-To setup the local sandbox, run `npm start`.
-
-test2

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Assumes valid [AWS credentials](https://arc.codes/docs/en/get-started/detailed-a
 ## Local Development
 
 To setup the local sandbox, run `npm start`.
+
+test

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Assumes valid [AWS credentials](https://arc.codes/docs/en/get-started/detailed-a
 
 To setup the local sandbox, run `npm start`.
 
-test
+test2

--- a/app.arc
+++ b/app.arc
@@ -12,4 +12,5 @@ post /publish
 @aws
 # profile default
 region us-east-1
+runtime nodejs18.x
 architecture arm64

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-cloudfront": "^3.58.0",
         "@contentful/rich-text-html-renderer": "^15.11.1",
         "contentful": "^9.1.18",
         "mysql2": "^3.6.5"
       },
       "devDependencies": {
         "@architect/architect": "^10.1.0",
+        "@aws-sdk/client-cloudfront": "^3.58.0",
         "eslint": "^8.11.0"
       },
       "engines": {
@@ -374,6 +374,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -383,7 +384,8 @@
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "3.0.0",
@@ -406,6 +408,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -413,7 +416,8 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "3.0.0",
@@ -440,6 +444,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -454,12 +459,14 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -469,12 +476,14 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -482,12 +491,14 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -497,7 +508,8 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
       "version": "3.454.0",
@@ -553,6 +565,7 @@
       "version": "3.457.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.457.0.tgz",
       "integrity": "sha512-jXyQLwF6V/RT+LW6XNMMQTnfGNexyBoUi7fxKq5oTQk6cJHN1ee27qHkuruYXdUJKMOELAopFfJenzliAKLTuw==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -882,6 +895,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
       "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -928,6 +942,7 @@
       "version": "3.454.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.454.0.tgz",
       "integrity": "sha512-0fDvr8WeB6IYO8BUCzcivWmahgGl/zDbaYfakzGnt4mrl5ztYaXE875WI6b7+oFcKMRvN+KLvwu5TtyFuNY+GQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -978,6 +993,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
       "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+      "dev": true,
       "dependencies": {
         "@smithy/smithy-client": "^2.1.15",
         "tslib": "^2.5.0"
@@ -990,6 +1006,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
       "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -1004,6 +1021,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
       "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.451.0",
         "@aws-sdk/credential-provider-process": "3.451.0",
@@ -1024,6 +1042,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
       "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.451.0",
         "@aws-sdk/credential-provider-ini": "3.451.0",
@@ -1045,6 +1064,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
       "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -1060,6 +1080,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
       "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.451.0",
         "@aws-sdk/token-providers": "3.451.0",
@@ -1077,6 +1098,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
       "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -1189,6 +1211,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
       "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/protocol-http": "^3.0.9",
@@ -1217,6 +1240,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
       "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/types": "^2.5.0",
@@ -1230,6 +1254,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
       "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/protocol-http": "^3.0.9",
@@ -1277,6 +1302,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
       "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.451.0",
         "@aws-sdk/types": "3.451.0",
@@ -1291,6 +1317,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
       "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -1322,6 +1349,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
       "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@aws-sdk/util-endpoints": "3.451.0",
@@ -1431,6 +1459,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
       "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.1.5",
         "@smithy/types": "^2.5.0",
@@ -1462,6 +1491,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
       "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -1509,6 +1539,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
       "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
@@ -1548,6 +1579,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
       "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/util-endpoints": "^1.0.4",
@@ -1561,6 +1593,7 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1572,6 +1605,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
       "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/types": "^2.5.0",
@@ -1583,6 +1617,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
       "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/node-config-provider": "^2.1.5",
@@ -1605,6 +1640,7 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -1613,6 +1649,7 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
       "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1869,6 +1906,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
       "integrity": "sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -1900,6 +1938,7 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.19.tgz",
       "integrity": "sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==",
+      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/types": "^2.6.0",
@@ -1915,6 +1954,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.2.tgz",
       "integrity": "sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==",
+      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/property-provider": "^2.0.15",
@@ -1930,6 +1970,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.14.tgz",
       "integrity": "sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.6.0",
@@ -1996,6 +2037,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
       "integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^3.0.10",
         "@smithy/querystring-builder": "^2.0.14",
@@ -2020,6 +2062,7 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.16.tgz",
       "integrity": "sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -2048,6 +2091,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.14.tgz",
       "integrity": "sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2057,6 +2101,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2079,6 +2124,7 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.16.tgz",
       "integrity": "sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==",
+      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^3.0.10",
         "@smithy/types": "^2.6.0",
@@ -2092,6 +2138,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.1.tgz",
       "integrity": "sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==",
+      "dev": true,
       "dependencies": {
         "@smithy/middleware-serde": "^2.0.14",
         "@smithy/node-config-provider": "^2.1.6",
@@ -2109,6 +2156,7 @@
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.21.tgz",
       "integrity": "sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==",
+      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/protocol-http": "^3.0.10",
@@ -2127,6 +2175,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.14.tgz",
       "integrity": "sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2139,6 +2188,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.8.tgz",
       "integrity": "sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2151,6 +2201,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.6.tgz",
       "integrity": "sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==",
+      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.15",
         "@smithy/shared-ini-file-loader": "^2.2.5",
@@ -2165,6 +2216,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.10.tgz",
       "integrity": "sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==",
+      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.14",
         "@smithy/protocol-http": "^3.0.10",
@@ -2180,6 +2232,7 @@
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.15.tgz",
       "integrity": "sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2192,6 +2245,7 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
       "integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2204,6 +2258,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
       "integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -2217,6 +2272,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.14.tgz",
       "integrity": "sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2229,6 +2285,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.7.tgz",
       "integrity": "sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0"
       },
@@ -2240,6 +2297,7 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.5.tgz",
       "integrity": "sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2252,6 +2310,7 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.16.tgz",
       "integrity": "sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==",
+      "dev": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^2.0.14",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -2270,6 +2329,7 @@
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.16.tgz",
       "integrity": "sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.8",
         "@smithy/types": "^2.6.0",
@@ -2284,6 +2344,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
       "integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2295,6 +2356,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.14.tgz",
       "integrity": "sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==",
+      "dev": true,
       "dependencies": {
         "@smithy/querystring-parser": "^2.0.14",
         "@smithy/types": "^2.6.0",
@@ -2305,6 +2367,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
       "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2317,6 +2380,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -2325,6 +2389,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
       "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2336,6 +2401,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
       "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2348,6 +2414,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2359,6 +2426,7 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.20.tgz",
       "integrity": "sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==",
+      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.15",
         "@smithy/smithy-client": "^2.1.16",
@@ -2374,6 +2442,7 @@
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.26.tgz",
       "integrity": "sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==",
+      "dev": true,
       "dependencies": {
         "@smithy/config-resolver": "^2.0.19",
         "@smithy/credential-provider-imds": "^2.1.2",
@@ -2391,6 +2460,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.5.tgz",
       "integrity": "sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==",
+      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/types": "^2.6.0",
@@ -2404,6 +2474,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2415,6 +2486,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.7.tgz",
       "integrity": "sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -2427,6 +2499,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.7.tgz",
       "integrity": "sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==",
+      "dev": true,
       "dependencies": {
         "@smithy/service-error-classification": "^2.0.7",
         "@smithy/types": "^2.6.0",
@@ -2440,6 +2513,7 @@
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.21.tgz",
       "integrity": "sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==",
+      "dev": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^2.2.7",
         "@smithy/node-http-handler": "^2.1.10",
@@ -2458,6 +2532,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2469,6 +2544,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
       "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2481,6 +2557,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.14.tgz",
       "integrity": "sha512-Q6gSz4GUNjNGhrfNg+2Mjy+7K4pEI3r82x1b/+3dSc03MQqobMiUrRVN/YK/4nHVagvBELCoXsiHAFQJNQ5BeA==",
+      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.14",
         "@smithy/types": "^2.6.0",
@@ -2775,7 +2852,8 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -3589,6 +3667,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
       "funding": [
         {
           "type": "paypal",
@@ -5949,7 +6028,8 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "node_modules/subleveldown": {
       "version": "5.0.1",
@@ -6124,7 +6204,8 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6273,6 +6354,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -6878,6 +6960,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -6887,7 +6970,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -6914,6 +6998,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -6921,7 +7006,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -6952,6 +7038,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -6966,7 +7053,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -6974,6 +7062,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -6983,7 +7072,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -6991,6 +7081,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -6998,7 +7089,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -7006,6 +7098,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -7015,7 +7108,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -7070,6 +7164,7 @@
       "version": "3.457.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.457.0.tgz",
       "integrity": "sha512-jXyQLwF6V/RT+LW6XNMMQTnfGNexyBoUi7fxKq5oTQk6cJHN1ee27qHkuruYXdUJKMOELAopFfJenzliAKLTuw==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -7381,6 +7476,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
       "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -7424,6 +7520,7 @@
       "version": "3.454.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.454.0.tgz",
       "integrity": "sha512-0fDvr8WeB6IYO8BUCzcivWmahgGl/zDbaYfakzGnt4mrl5ztYaXE875WI6b7+oFcKMRvN+KLvwu5TtyFuNY+GQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -7471,6 +7568,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
       "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+      "dev": true,
       "requires": {
         "@smithy/smithy-client": "^2.1.15",
         "tslib": "^2.5.0"
@@ -7480,6 +7578,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
       "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -7491,6 +7590,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
       "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.451.0",
         "@aws-sdk/credential-provider-process": "3.451.0",
@@ -7508,6 +7608,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
       "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.451.0",
         "@aws-sdk/credential-provider-ini": "3.451.0",
@@ -7526,6 +7627,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
       "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -7538,6 +7640,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
       "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/client-sso": "3.451.0",
         "@aws-sdk/token-providers": "3.451.0",
@@ -7552,6 +7655,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
       "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -7640,6 +7744,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
       "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/protocol-http": "^3.0.9",
@@ -7662,6 +7767,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
       "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/types": "^2.5.0",
@@ -7672,6 +7778,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
       "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/protocol-http": "^3.0.9",
@@ -7710,6 +7817,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
       "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.451.0",
         "@aws-sdk/types": "3.451.0",
@@ -7721,6 +7829,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
       "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
@@ -7746,6 +7855,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
       "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@aws-sdk/util-endpoints": "3.451.0",
@@ -7832,6 +7942,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
       "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.1.5",
         "@smithy/types": "^2.5.0",
@@ -7857,6 +7968,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
       "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -7901,6 +8013,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
       "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
@@ -7928,6 +8041,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
       "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/util-endpoints": "^1.0.4",
@@ -7938,6 +8052,7 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -7946,6 +8061,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
       "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/types": "^2.5.0",
@@ -7957,6 +8073,7 @@
       "version": "3.451.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
       "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.451.0",
         "@smithy/node-config-provider": "^2.1.5",
@@ -7968,6 +8085,7 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -7976,6 +8094,7 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
       "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8163,6 +8282,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
       "integrity": "sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8191,6 +8311,7 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.19.tgz",
       "integrity": "sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==",
+      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/types": "^2.6.0",
@@ -8203,6 +8324,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.2.tgz",
       "integrity": "sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==",
+      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/property-provider": "^2.0.15",
@@ -8215,6 +8337,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.14.tgz",
       "integrity": "sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.6.0",
@@ -8269,6 +8392,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
       "integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^3.0.10",
         "@smithy/querystring-builder": "^2.0.14",
@@ -8293,6 +8417,7 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.16.tgz",
       "integrity": "sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -8315,6 +8440,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.14.tgz",
       "integrity": "sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8324,6 +8450,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8343,6 +8470,7 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.16.tgz",
       "integrity": "sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==",
+      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^3.0.10",
         "@smithy/types": "^2.6.0",
@@ -8353,6 +8481,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.1.tgz",
       "integrity": "sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==",
+      "dev": true,
       "requires": {
         "@smithy/middleware-serde": "^2.0.14",
         "@smithy/node-config-provider": "^2.1.6",
@@ -8367,6 +8496,7 @@
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.21.tgz",
       "integrity": "sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==",
+      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/protocol-http": "^3.0.10",
@@ -8382,6 +8512,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.14.tgz",
       "integrity": "sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8391,6 +8522,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.8.tgz",
       "integrity": "sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8400,6 +8532,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.6.tgz",
       "integrity": "sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==",
+      "dev": true,
       "requires": {
         "@smithy/property-provider": "^2.0.15",
         "@smithy/shared-ini-file-loader": "^2.2.5",
@@ -8411,6 +8544,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.10.tgz",
       "integrity": "sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==",
+      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^2.0.14",
         "@smithy/protocol-http": "^3.0.10",
@@ -8423,6 +8557,7 @@
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.15.tgz",
       "integrity": "sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8432,6 +8567,7 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
       "integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8441,6 +8577,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
       "integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -8451,6 +8588,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.14.tgz",
       "integrity": "sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8460,6 +8598,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.7.tgz",
       "integrity": "sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0"
       }
@@ -8468,6 +8607,7 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.5.tgz",
       "integrity": "sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8477,6 +8617,7 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.16.tgz",
       "integrity": "sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==",
+      "dev": true,
       "requires": {
         "@smithy/eventstream-codec": "^2.0.14",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -8492,6 +8633,7 @@
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.16.tgz",
       "integrity": "sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==",
+      "dev": true,
       "requires": {
         "@smithy/middleware-stack": "^2.0.8",
         "@smithy/types": "^2.6.0",
@@ -8503,6 +8645,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
       "integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8511,6 +8654,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.14.tgz",
       "integrity": "sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==",
+      "dev": true,
       "requires": {
         "@smithy/querystring-parser": "^2.0.14",
         "@smithy/types": "^2.6.0",
@@ -8521,6 +8665,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
       "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -8530,6 +8675,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8538,6 +8684,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
       "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8546,6 +8693,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
       "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dev": true,
       "requires": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
@@ -8555,6 +8703,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8563,6 +8712,7 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.20.tgz",
       "integrity": "sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==",
+      "dev": true,
       "requires": {
         "@smithy/property-provider": "^2.0.15",
         "@smithy/smithy-client": "^2.1.16",
@@ -8575,6 +8725,7 @@
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.26.tgz",
       "integrity": "sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==",
+      "dev": true,
       "requires": {
         "@smithy/config-resolver": "^2.0.19",
         "@smithy/credential-provider-imds": "^2.1.2",
@@ -8589,6 +8740,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.5.tgz",
       "integrity": "sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==",
+      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.1.6",
         "@smithy/types": "^2.6.0",
@@ -8599,6 +8751,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8607,6 +8760,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.7.tgz",
       "integrity": "sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.6.0",
         "tslib": "^2.5.0"
@@ -8616,6 +8770,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.7.tgz",
       "integrity": "sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==",
+      "dev": true,
       "requires": {
         "@smithy/service-error-classification": "^2.0.7",
         "@smithy/types": "^2.6.0",
@@ -8626,6 +8781,7 @@
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.21.tgz",
       "integrity": "sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==",
+      "dev": true,
       "requires": {
         "@smithy/fetch-http-handler": "^2.2.7",
         "@smithy/node-http-handler": "^2.1.10",
@@ -8641,6 +8797,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -8649,6 +8806,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
       "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -8658,6 +8816,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.14.tgz",
       "integrity": "sha512-Q6gSz4GUNjNGhrfNg+2Mjy+7K4pEI3r82x1b/+3dSc03MQqobMiUrRVN/YK/4nHVagvBELCoXsiHAFQJNQ5BeA==",
+      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^2.0.14",
         "@smithy/types": "^2.6.0",
@@ -8875,7 +9034,8 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
     },
     "boxen": {
       "version": "5.1.2",
@@ -9497,6 +9657,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -11241,7 +11402,8 @@
     "strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "subleveldown": {
       "version": "5.0.1",
@@ -11373,7 +11535,8 @@
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -11499,7 +11662,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "mysql2": "^3.6.5"
       },
       "devDependencies": {
-        "@architect/architect": "^10.1.0",
+        "@architect/architect": "^10.11.2",
         "@aws-sdk/client-cloudfront": "^3.58.0",
         "eslint": "^8.11.0"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mysql2": "^3.6.5"
   },
   "devDependencies": {
-    "@architect/architect": "^10.1.0",
+    "@architect/architect": "^10.11.2",
     "@aws-sdk/client-cloudfront": "^3.58.0",
     "eslint": "^8.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "start": "arc sandbox"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudfront": "^3.58.0",
     "@contentful/rich-text-html-renderer": "^15.11.1",
     "contentful": "^9.1.18",
     "mysql2": "^3.6.5"
   },
   "devDependencies": {
     "@architect/architect": "^10.1.0",
+    "@aws-sdk/client-cloudfront": "^3.58.0",
     "eslint": "^8.11.0"
   }
 }


### PR DESCRIPTION
resolves  #37 

1. Move **@aws-sdk/*** to `devDependencies` since it already comes bundled with Lambda
1. Set NodeJS version in Architect config
1. Upgrade to latest version of Architect (not needed, just left over from testing)